### PR TITLE
download() GL/Tensor methods update

### DIFF
--- a/dist/TCompute.js
+++ b/dist/TCompute.js
@@ -9,9 +9,12 @@
 
 
 
+var _withTHREE = false
+
 try {
 	if ( Number( THREE.REVISION ) >= 76 ) {
 		THREE.Compute = TCompute
+		_withTHREE = true
 	}
 } catch ( error ) {}
 
@@ -52,6 +55,7 @@ function TCompute( renderer ) {
 	this.renderer = renderer
 	this.context = gl
 	this.state = state
+	this.withTHREE = _withTHREE
 
 	// Capabilities
 	var float_support
@@ -107,9 +111,12 @@ TCompute.prototype.setupPrograms = function() {
 	// Shader common function sources
 	this.functions_src = {
 		modulo:				"float modulo( float x, float y ) {\r\n\treturn x - y * floor( ( x + 0.5 ) / ( y ) );\r\n}\r\n",
-		get_indices:		"vec2 get_indices( float col_t, float cols, float row_t, float rows ) {\r\n\tfloat col_index = floor( col_t * cols );\r\n\tfloat row_index = floor( row_t * rows );\r\n\r\n\treturn vec2( col_index, row_index );\r\n}\r\n\r\nvec2 getXY( vec2 uv, vec2 shape ) {\r\n\tfloat col_index = floor( uv.s * shape.x );\r\n\tfloat row_index = floor( uv.t * shape.y );\r\n\r\n\treturn vec2( col_index, row_index );\r\n}\r\n",
-		get_coords:			"vec2 get_coords( float index, float cols, float cols_halfp, float rows, float row_halfp ) {\r\n\tfloat col_index = modulo( index, cols ); // custom mod function addressing float division rounding error\r\n\tfloat row_index = floor( ( index + 0.5 ) / cols ); // as above\r\n\t\r\n\treturn vec2( col_index * cols_halfp * 2.0 + cols_halfp, row_index * row_halfp * 2.0 + row_halfp );\r\n}\r\n\r\nvec2 getUV( float index, vec2 shape, vec2 halfp ) {\r\n\tfloat x = modulo( index, shape.x ); // custom mod function addressing float division rounding error\r\n\tfloat y = floor( ( index + 0.5 ) / shape.x ); // as above\r\n\t\r\n\treturn vec2( x * halfp.x * 2.0 + halfp.x, y * halfp.y * 2.0 + halfp.y );\r\n}\r\n",
-		get_channel_value:	"float get_channel_value( sampler2D texture, int channel, vec2 xy ) {\r\n\tfloat value = 0.0;\r\n\tif ( channel == 0 ) {\r\n\t\tvalue = texture2D( texture, xy ).r;\r\n\t} else if ( channel == 1 ) {\r\n\t\tvalue = texture2D( texture, xy ).g;\r\n\t} else if ( channel == 2 ) {\r\n\t\tvalue = texture2D( texture, xy ).b;\r\n\t} else if ( channel == 3 ) {\r\n\t\tvalue = texture2D( texture, xy ).a;\r\n\t}\r\n\treturn value;\r\n}\r\n\r\nfloat getUVvalue( sampler2D texture, int channel, vec2 xy ) {\r\n\tfloat value = 0.0;\r\n\tif ( channel == 0 ) {\r\n\t\tvalue = texture2D( texture, xy ).r;\r\n\t} else if ( channel == 1 ) {\r\n\t\tvalue = texture2D( texture, xy ).g;\r\n\t} else if ( channel == 2 ) {\r\n\t\tvalue = texture2D( texture, xy ).b;\r\n\t} else if ( channel == 3 ) {\r\n\t\tvalue = texture2D( texture, xy ).a;\r\n\t}\r\n\treturn value;\r\n}\r\n",
+		getUV:				"vec2 getUV( float index, vec2 shape, vec2 halfp ) {\r\n\tfloat x = modulo( index, shape.x ); // custom mod function addressing float division rounding error\r\n\tfloat y = floor( ( index + 0.5 ) / shape.x ); // as above\r\n\t\r\n\treturn vec2( x * halfp.x * 2.0 + halfp.x, y * halfp.y * 2.0 + halfp.y );\r\n}\r\n",
+		getUVvalue:			"float getUVvalue( sampler2D texture, int channel, vec2 xy ) {\r\n\tfloat value = 0.0;\r\n\tif ( channel == 0 ) {\r\n\t\tvalue = texture2D( texture, xy ).r;\r\n\t} else if ( channel == 1 ) {\r\n\t\tvalue = texture2D( texture, xy ).g;\r\n\t} else if ( channel == 2 ) {\r\n\t\tvalue = texture2D( texture, xy ).b;\r\n\t} else if ( channel == 3 ) {\r\n\t\tvalue = texture2D( texture, xy ).a;\r\n\t}\r\n\treturn value;\r\n}\r\n",
+		getXY:				"vec2 getXY( vec2 uv, vec2 shape ) {\r\n\tfloat col_index = floor( uv.s * shape.x );\r\n\tfloat row_index = floor( uv.t * shape.y );\r\n\r\n\treturn vec2( col_index, row_index );\r\n}\r\n",
+		get_indices:		"vec2 get_indices( float col_t, float cols, float row_t, float rows ) {\r\n\tfloat col_index = floor( col_t * cols );\r\n\tfloat row_index = floor( row_t * rows );\r\n\r\n\treturn vec2( col_index, row_index );\r\n}\r\n",
+		get_coords:			"vec2 get_coords( float index, float cols, float cols_halfp, float rows, float row_halfp ) {\r\n\tfloat col_index = modulo( index, cols ); // custom mod function addressing float division rounding error\r\n\tfloat row_index = floor( ( index + 0.5 ) / cols ); // as above\r\n\t\r\n\treturn vec2( col_index * cols_halfp * 2.0 + cols_halfp, row_index * row_halfp * 2.0 + row_halfp );\r\n}\r\n",
+		get_channel_value:	"float get_channel_value( sampler2D texture, int channel, vec2 xy ) {\r\n\tfloat value = 0.0;\r\n\tif ( channel == 0 ) {\r\n\t\tvalue = texture2D( texture, xy ).r;\r\n\t} else if ( channel == 1 ) {\r\n\t\tvalue = texture2D( texture, xy ).g;\r\n\t} else if ( channel == 2 ) {\r\n\t\tvalue = texture2D( texture, xy ).b;\r\n\t} else if ( channel == 3 ) {\r\n\t\tvalue = texture2D( texture, xy ).a;\r\n\t}\r\n\treturn value;\r\n}\r\n",
 		set_channel_value:	"vec4 set_channel_value( int channel, float value ) {\t\r\n\tif ( channel == 0 ) {\r\n\t\treturn vec4( value, 0.0, 0.0, 0.0 );\r\n\t}\r\n\tif ( channel == 1 ) {\r\n\t\treturn vec4( 0.0, value, 0.0, 0.0 );\r\n\t}\r\n\tif ( channel == 2 ) {\r\n\t\treturn vec4( 0.0, 0.0, value, 0.0 );\r\n\t}\r\n\tif ( channel == 3 ) {\r\n\t\treturn vec4( 0.0, 0.0, 0.0, value );\r\n\t}\t\r\n\treturn vec4( 0.0, 0.0, 0.0, 0.0 );\t// should not happen\r\n}\r\n",
 		mix_channel_value:	"vec4 mix_channel_value( vec4 rgba, int channel, float value ) {\t\r\n\tif ( channel == 0 ) {\r\n\t\trgba.r = value;\r\n\t}\r\n\tif ( channel == 1 ) {\r\n\t\trgba.g = value;\r\n\t}\r\n\tif ( channel == 2 ) {\r\n\t\trgba.b = value;\r\n\t}\r\n\tif ( channel == 3 ) {\r\n\t\trgba.a = value;\r\n\t}\r\n\treturn rgba;\r\n}\r\n"
 	}
@@ -117,14 +124,12 @@ TCompute.prototype.setupPrograms = function() {
 	
 	// Shader main function sources
 	this.main_src = {
-		/*render_unpacked:	fs.readFileSync('./src/glsl/m_render_unpacked.glsl', 'utf8'),
-		render_packed:		fs.readFileSync('./src/glsl/m_render_packed.glsl', 'utf8'),*/
-		download:			"void main( void ) {\r\n\tfloat col_t = UVs.s;\r\n\t#ifdef FLIPY\r\n\t\tfloat row_t = 1.0 - UVs.t;\r\n\t#else\r\n\t\tfloat row_t = UVs.t;\r\n\t#endif\r\n\r\n\tgl_FragColor = texture2D( A, vec2( col_t, row_t ) );\r\n}\r\n",
+		download:			"void main( void ) {\r\n\tfloat S = UVs.s;\r\n\tfloat T = UVs.t;\r\n\t#ifdef FLIPY\r\n\t\tT = 1.0 - UVs.t;\t\t\r\n\t#endif\r\n\r\n\tgl_FragColor = texture2D( A, vec2( S, T ) );\r\n}\r\n",
 		download_packed:	"void main( void ) {\r\n\tfloat S = UVs.s;\r\n\tfloat T = UVs.t;\r\n\t#ifdef FLIPY\r\n\t\tT = 1.0 - UVs.t;\t\t\r\n\t#endif\r\n\r\n\t// get this pixel's row(.x) / column(.y) index\r\n\tvec2 PIXEL = getXY( vec2( S, T ), OUTshape );\r\n\r\n\t// get implied flat index ( as used in cpu buffers )\r\n\tfloat Pbuffer_i = PIXEL.y * OUTshape.x * OUTchannels + PIXEL.x * OUTchannels;\r\n\r\n\t// corresponding unpacked flat index sequence\r\n\tvec4 UPbuffer_i = vec4( Pbuffer_i, Pbuffer_i + 1.0, Pbuffer_i + 2.0, Pbuffer_i + 3.0 );\r\n\r\n\t// get the sequence of coordinates of unpacked texture\r\n\tvec2 UPs = getUV( UPbuffer_i.x, UPshape, UPhalfp );\r\n\tvec2 UPt = getUV( UPbuffer_i.y, UPshape, UPhalfp );\r\n\tvec2 UPp = getUV( UPbuffer_i.z, UPshape, UPhalfp );\r\n\tvec2 UPq = getUV( UPbuffer_i.w, UPshape, UPhalfp );\r\n\r\n\t// read sequence of four values from unpacked texture\r\n\tfloat r = getUVvalue( A, Achan, UPs );\r\n\tfloat g = getUVvalue( A, Achan, UPt );\r\n\tfloat b = getUVvalue( A, Achan, UPp );\r\n\tfloat a = getUVvalue( A, Achan, UPq );\r\n\r\n\t// output values PACKED\r\n\tgl_FragColor = vec4( r, g, b, a );\r\n}\r\n",
 		read_packed:		"void main( void ) {\r\n\tgl_FragColor = texture2D( A, UVs );\r\n}\r\n",
 		read_packed_padded:	"void main( void ) {\r\n\t// get the implied row and column from .t and .s of passed (output) texture coordinate.\r\n\tfloat col_t = UVs.s;\r\n\tfloat row_t = UVs.t;\r\n\t\r\n\t// get the implied row and column indices\r\n\tvec2 rowcol = get_indices( col_t, OUTshape.x, row_t, OUTshape.y );\r\n\t\r\n\t// this pixel index as if unpacked (up_cols = cols * 4.0)\r\n\tfloat index = rowcol.y * up_cols + rowcol.x * 4.0;\r\n\t\r\n\t// expanded indices per channel\r\n\tfloat index_r = index + 0.1;\r\n\tfloat index_g = index + 1.1;\r\n\tfloat index_b = index + 2.1;\r\n\tfloat index_a = index + 3.1;\r\n\t\r\n\t// number of padded elements(pixels) up to this index\r\n\tfloat pads_r = floor( index_r / up_cols_padded );\r\n\tfloat pads_g = floor( index_g / up_cols_padded );\r\n\tfloat pads_b = floor( index_b / up_cols_padded );\r\n\tfloat pads_a = floor( index_a / up_cols_padded );\r\n\t\r\n\t// new index accounting padding\r\n\tfloat nindex_r = index_r + pads_r * pad;\r\n\tfloat nindex_g = index_g + pads_g * pad;\r\n\tfloat nindex_b = index_b + pads_b * pad;\r\n\tfloat nindex_a = index_a + pads_a * pad;\r\n\r\n\t// new channel based on new index ( these get shifted )\r\n\tfloat nchannel_r = floor( mod( nindex_r, 4.0 ) );\r\n\tfloat nchannel_g = floor( mod( nindex_g, 4.0 ) );\r\n\tfloat nchannel_b = floor( mod( nindex_b, 4.0 ) );\r\n\tfloat nchannel_a = floor( mod( nindex_a, 4.0 ) );\r\n\t\r\n\t// can be optimized, at most 2 pixels should be read\r\n\t// get the sequence of coordinates of texture as if unpacked\r\n\tvec2 up_s = get_coords( nindex_r, up_cols, up_col_hstep, OUTshape.y, OUThalfp.y );\r\n\tvec2 up_t = get_coords( nindex_g, up_cols, up_col_hstep, OUTshape.y, OUThalfp.y );\r\n\tvec2 up_p = get_coords( nindex_b, up_cols, up_col_hstep, OUTshape.y, OUThalfp.y );\r\n\tvec2 up_q = get_coords( nindex_a, up_cols, up_col_hstep, OUTshape.y, OUThalfp.y );\r\n\t\r\n\t// read four values from texture considering the new channels \r\n\tfloat r = get_channel_value( A, int(nchannel_r), up_s );\r\n\tfloat g = get_channel_value( A, int(nchannel_g), up_t );\r\n\tfloat b = get_channel_value( A, int(nchannel_b), up_p );\r\n\tfloat a = get_channel_value( A, int(nchannel_a), up_q );\r\n\t\r\n\tgl_FragColor = vec4( r, g, b, a );\r\n}\r\n",
-		duplicate:			"void main( void ) {\r\n\tfloat col_t = UVs.s;\r\n\tfloat row_t = UVs.t;\r\n\t/*#ifdef FLIPY\r\n\tfloat row_t = 1.0 - UVs.t;\r\n\t#else\r\n\tfloat row_t = UVs.t;\r\n\t#endif*/\r\n\r\n\tfloat A_value = get_channel_value( A, Achan, vec2( col_t, row_t ) );\r\n\tgl_FragColor = set_channel_value( OUTchan, A_value );\r\n}\r\n",
-		duplicate_packed:	"void main( void ) {\r\n\tfloat col_t = UVs.s;\r\n\tfloat row_t = UVs.t;\r\n\t/*#ifdef FLIPY\r\n\tfloat row_t = 1.0 - UVs.t;\r\n\t#else\r\n\tfloat row_t = UVs.t;\r\n\t#endif*/\r\n\r\n\tgl_FragColor = texture2D( A, vec2( col_t, row_t ) );\r\n}\r\n",
+		duplicate:			"void main( void ) {\r\n\tfloat S = UVs.s;\r\n\tfloat T = UVs.t;\r\n\t#ifdef FLIPY\r\n\t\tT = 1.0 - UVs.t;\t\t\r\n\t#endif\r\n\r\n\tfloat A_value = get_channel_value( A, Achan, vec2( S, T ) );\r\n\tgl_FragColor = set_channel_value( OUTchan, A_value );\r\n}\r\n",
+		duplicate_packed:	"void main( void ) {\r\n\tfloat S = UVs.s;\r\n\tfloat T = UVs.t;\r\n\t#ifdef FLIPY\r\n\t\tT = 1.0 - UVs.t;\t\t\r\n\t#endif\r\n\r\n\tgl_FragColor = texture2D( A, vec2( S, T ) );\r\n}\r\n",
 		pack:				"void main( void ) {\r\n\t// get the implied row and column from .t and .s of passed (output) texture coordinate.\r\n\tfloat col_t = UVs.s;\r\n\tfloat row_t = UVs.t;\r\n\t\r\n\t// get the implied row and column indices\r\n\tvec2 rowcol = get_indices( col_t, OUTshape.x, row_t, OUTshape.y );\r\n\t\r\n\t// unpacked row and column index (columns are multiplied by 4 channels)\r\n\tfloat up_col = rowcol.x * 4.0;\r\n\tfloat up_row = rowcol.y / OUTshape.y + OUThalfp.y;\r\n\t\r\n\t// set a sequence of four indices\r\n\tvec4 seq_col_indices = vec4( up_col, up_col + 1.0, up_col + 2.0, up_col + 3.0 );\r\n\t\r\n\t// get the sequence of coordinates of unpacked texture\r\n\tvec2 up_s = vec2( seq_col_indices.x / up_cols + up_col_hstep, up_row );\r\n\tvec2 up_t = vec2( seq_col_indices.y / up_cols + up_col_hstep, up_row );\r\n\tvec2 up_p = vec2( seq_col_indices.z / up_cols + up_col_hstep, up_row );\r\n\tvec2 up_q = vec2( seq_col_indices.w / up_cols + up_col_hstep, up_row );\r\n\t\r\n\t// read four values from unpacked texture\r\n\tfloat r = get_channel_value( A, Achan, up_s );\r\n\tfloat g = get_channel_value( A, Achan, up_t );\r\n\tfloat b = get_channel_value( A, Achan, up_p );\r\n\tfloat a = get_channel_value( A, Achan, up_q );\r\n\r\n\tgl_FragColor = vec4( r, g, b, a );\r\n}\r\n",
 		unpack:				"void main( void ) {\r\n\tfloat col_t = UVs.s;\r\n\tfloat row_t = UVs.t;\r\n\r\n\tvec2 rowcol = get_indices( col_t, OUTshape.x, row_t, OUTshape.y );\r\n\tfloat p_col_index = floor( rowcol.x / 4.0 );\r\n\tfloat p_index = floor( rowcol.y * p_cols + p_col_index ); //  + 0.1\r\n\r\n\tint Achan = int( mod( rowcol.x, 4.0 ) );\r\n\tvec2 packed_st = get_coords( p_index, p_cols, p_col_hstep, OUTshape.y, OUThalfp.y );\r\n\tfloat value = get_channel_value( A, Achan, packed_st );\r\n\r\n\tgl_FragColor = set_channel_value( OUTchan, value );\r\n}\r\n",
 		transpose:			"void main( void ) {\t\r\n\tfloat value = get_channel_value( A, Achan, vec2( UVs.y, UVs.x ) );\t\r\n\tgl_FragColor = set_channel_value( OUTchan, value );\r\n}"
@@ -260,13 +265,13 @@ TCompute.prototype.setupFramebuffer = function() {
 	this.state.viewport( targetViewport )
 	
 	this.framebuffer = gl.createFramebuffer()
+	this.fbTexture = this.setupTexture( [ 2, 2 ], null, gl.RGBA, gl.FLOAT )
 	
-	var texture = this.setupTexture( 2, 2, null, false, gl.RGBA, gl.FLOAT )
-	this.state.bindTexture( gl.TEXTURE_2D, texture )
+	this.state.bindTexture( gl.TEXTURE_2D, this.fbTexture )
 	
 	this.state.texImage2D( gl.TEXTURE_2D, 0, gl.RGBA, 2, 2, 0, gl.RGBA, gl.FLOAT, null )
 	gl.bindFramebuffer( gl.FRAMEBUFFER, this.framebuffer )
-	gl.framebufferTexture2D( gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0 )
+	gl.framebufferTexture2D( gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this.fbTexture, 0 )
 
 	if( gl.checkFramebufferStatus( gl.FRAMEBUFFER ) != gl.FRAMEBUFFER_COMPLETE )
 		console.error( 'bindFramebuffer(): Framebuffer not complete' )
@@ -276,13 +281,19 @@ TCompute.prototype.setupFramebuffer = function() {
 
 /* Create a texture for both input and output
  */
-TCompute.prototype.setupTexture = function( M, N, data, packed, glFormat, glType ) {
+TCompute.prototype.setupTexture = function( shape, data, glFormat, glType ) {
 	var gl = this.context
 	
-	var W = packed ? Math.ceil( N / 4 ) : N
-	var H = M
+	/*var W = packed ? Math.ceil( N / 4 ) : N
+	var H = M*/
+	
+	var width = shape[ 1 ]
+	var height = shape[ 0 ]
 
 	var texture = gl.createTexture()
+	
+	/*texture.width = W
+	texture.height = H*/
 	
 	this.state.bindTexture( gl.TEXTURE_2D, texture )
 	
@@ -290,7 +301,7 @@ TCompute.prototype.setupTexture = function( M, N, data, packed, glFormat, glType
 	gl.pixelStorei( gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false )
 	//gl.pixelStorei( gl.UNPACK_ALIGNMENT, 4 )
 
-	this.state.texImage2D( gl.TEXTURE_2D, 0, glFormat, W, H, 0, glFormat, glType, data )
+	this.state.texImage2D( gl.TEXTURE_2D, 0, glFormat, width, height, 0, glFormat, glType, data )
 	
 	gl.texParameteri( gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE )
 	gl.texParameteri( gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE )
@@ -420,6 +431,29 @@ TCompute.prototype.unbindTextures = function( textures ) {
 	}
 }
 
+// SHADER GENERATION
+TCompute.prototype.gatherVaryings = function() {
+	// compose string
+	var varyings_str = ''
+
+	varyings_str += 'varying vec2\t\tUVs;\r\n'
+	
+	return varyings_str + '\r\n'
+}
+TCompute.prototype.gatherSettings = function() {
+	// compose string
+	var settings_str = ''
+	
+	settings_str += 'precision highp float;\r\n'
+	settings_str += 'const float OUTchannels = 4.0;\r\n'
+	
+	for ( var s in this.computePass.settings ) {
+		if ( this.computePass.settings[ s ] ) settings_str += '#define ' + s.toUpperCase() + '\r\n'
+	}
+	
+	return settings_str + '\r\n'
+}
+
 TCompute.prototype.gatherUniforms = function() {
 	var uniforms = {}
 	
@@ -462,7 +496,54 @@ TCompute.prototype.gatherUniforms = function() {
 		}
 	}
 
-	return uniforms
+	// compose string
+	var str_uniforms = ''
+	for ( var u in uniforms ) {
+		var uniform = uniforms[ u ]
+		var type = uniform.type
+		var comment = uniform.comment || ''
+		str_uniforms += 'uniform ' + type + '\t ' + u + ';\t' + comment + '\r\n'
+	}
+	
+	return str_uniforms + '\r\n'
+}
+
+TCompute.prototype.gatherFunctions = function() {
+	var found_functions = {}
+	var ffnames = ''
+	
+	// check for functions in main source, mantain order
+	for ( var name in _shaderSources.functions ) {
+		var source = _shaderSources.functions[ name ]
+		var functionPosition = this.computePass.main.indexOf( String( name ) )		
+		if ( functionPosition > -1 ) {
+			found_functions[ functionPosition + 10000 ] = { name: name, source: source }
+			ffnames += name + ' '
+			
+		}
+	}
+	// check for functions within found functions, mantain order, prevent duplicates
+	var fc = 0
+	for ( var name in _shaderSources.functions ) {
+		var source = _shaderSources.functions[ name ]
+		for ( var ff in found_functions ) {
+			var ffname = found_functions[ ff ].name
+			var ffsource = found_functions[ ff ].source			
+			var notfoundyet = !ffnames.includes( String( name ) )
+			if ( ffsource.includes( String( name ) ) && notfoundyet ) {
+				found_functions[ fc ] = { name: name, source: source }
+				ffnames += name + ' '
+			}			
+		}
+		fc++
+	}
+	
+	// compose string
+	var functions_str = ''
+	for ( var f in found_functions ) {
+		functions_str += found_functions[ f ].source
+	}
+	return functions_str + '\r\n'
 }
 
 TCompute.prototype.generateProgram = function( program_name, debug ) {
@@ -476,43 +557,21 @@ TCompute.prototype.generateProgram = function( program_name, debug ) {
 		//var attributes = this.gatherAttributes()
 
 		// FRAGMENT
-		//var frag_src = this.shaders_src.dynamic_fragment
-		var frag_src = '// Shader: ' + program_name + ' ( generated )\r\n'
+		var frag_src = '// Shader: ' + program_name + '\r\n'
 		frag_src += '\r\n'
 		
 		frag_src += '// SETTINGS\r\n'
-		frag_src += 'precision highp float;\r\n'
-		frag_src += 'const float OUTchannels = 4.0;\r\n'
-		var str_settings = ''		
-		for ( var s in this.computePass.settings ) {
-			if ( this.computePass.settings[ s ] ) str_settings += '#define ' + s.toUpperCase() + '\r\n'
-		}
-		frag_src += str_settings + '\r\n'
+		frag_src += this.gatherSettings()
 		
 		frag_src += '// VARYINGS\r\n'
-		frag_src += 'varying vec2\t\tUVs;\r\n'
-		frag_src += '\r\n'
-		//var varyings = this.gatherVaryings()
+		frag_src += this.gatherVaryings()
 		
 		frag_src += '// UNIFORMS\r\n'
-		var uniforms = this.gatherUniforms()
-		
-		var str_uniforms = ''
-		for ( var u in uniforms ) {
-			var uniform = uniforms[ u ]
-			var type = uniform.type
-			var comment = uniform.comment || ''
-			str_uniforms += 'uniform ' + type + '\t ' + u + ';\t' + comment + '\r\n'
-		}
-		frag_src += str_uniforms + '\r\n'		
+		frag_src += this.gatherUniforms()
 		
 		frag_src += '// FUNCTIONS\r\n'
-		var str_functions = ''
-		for ( var f in this.computePass.functions ) {
-			str_functions += this.computePass.functions[ f ] + '\r\n'
-		}
-		frag_src += str_functions + '\r\n'
-		
+		frag_src += this.gatherFunctions()
+
 		frag_src += '// MAIN\r\n'
 		frag_src += this.computePass.main + '\r\n'
 		
@@ -529,6 +588,8 @@ TCompute.prototype.generateProgram = function( program_name, debug ) {
 
 TCompute.prototype.renderPass = function() {
 	var gl = this.context
+	
+	// TODO: binds caching, if sharing context how to inspect externally bound buffers?
 	
 	gl.useProgram( this.computePass.program )
 	
@@ -553,11 +614,11 @@ TCompute.prototype.renderPass = function() {
 	to the end of the array instead of having padded 0s per each row to prevent any user postprocessing
 	this is done at the shader level but must be handled when generating the CPU array
 */
-TCompute.prototype.readFloat = function( M, N, packed ) {
+TCompute.prototype.readFramebuffer = function( shape ) {
 	var gl = this.context
 
-	var W = packed ? Math.ceil( N / 4 ) : N
-	var H = M
+	var W = shape[ 1 ]
+	var H = shape[ 0 ]
 	var size = H * W * Float32Array.BYTES_PER_ELEMENT * 4
 
 	// create destination buffer
@@ -566,22 +627,17 @@ TCompute.prototype.readFloat = function( M, N, packed ) {
 	var readBuffer = new Float32Array( rawbuffer )
 	gl.readPixels( 0, 0, W, H, gl.RGBA, gl.FLOAT, readBuffer )
 
-	var sub_end = ( size - M * N * Float32Array.BYTES_PER_ELEMENT ) / 4
-	
-	// !!?? subarray() must use negative indexes of the relevant part else the full typed array is returned
-	// Must use negative indexes
-	return !packed || sub_end == 0 ? readBuffer : readBuffer.subarray( -size, -sub_end )
+	return readBuffer.subarray( 0, size )
 }
 
 /*	float texture read, allows output as packed+deferred or unpacked
  */
-TCompute.prototype.download = function( M, N, tensor, out, packed ) {
+TCompute.prototype.download = function( output, asPacked, tensor ) {
 	var objects,
 		framebuffer,
 		data = {},
 		textures = {},
 		settings = {},
-		functions = {},
 		main,
 		program_name
 
@@ -589,7 +645,15 @@ TCompute.prototype.download = function( M, N, tensor, out, packed ) {
 	objects = this.buffers.framequad
 
 	// Framebuffer
-	framebuffer = { width: N, height: M, texture: out, channel: out.channel || 0, bindChannel: false, bindShape: true }
+	// TODO: pass a 'out' tensor object instead of texture,
+	// to facilitade framebuffer / settings configuration
+	var M = tensor.shape[ 0 ]
+	var N = tensor.shape[ 1 ]
+	/*var shape = [ M, N ]
+	
+	var out = gl.setupTexture( shape, null, gl.context.RGBA, gl.context.FLOAT )*/
+	
+	framebuffer = { width: N, height: M, texture: output, channel: tensor.channel || 0, bindChannel: false, bindShape: true }
 
 	// Data
 
@@ -597,10 +661,9 @@ TCompute.prototype.download = function( M, N, tensor, out, packed ) {
 	textures.A = { type: 'sampler2D', value: tensor, bindChannel: true, bindShape: true }
 
 	// GLSL Settings
+	// TODO: tie settings to passed textures? may disallow some shader caching
+	// some settings should be prefilled in any case
 	settings.flipy = this.glSettings.flipy
-
-	// GLSL Functions
-	// TODO: automate function include
 
 	// GLSL Main
 	main = this.main_src.download
@@ -608,35 +671,24 @@ TCompute.prototype.download = function( M, N, tensor, out, packed ) {
 	// GLSL Name
 	program_name = 'download'
 
-	if ( packed ) {
+	if ( asPacked ) {
 		// GLSL Option Name
-		program_name += '_packed'
+		program_name += '_asPacked'
 
-		// Data
-		var W = Math.ceil( N / 4 )
-		var H = M
-
-		framebuffer.width = W
-
-		var up_shape = new Float32Array( [ N, M ] )
-		var up_halfp = new Float32Array( [ ( 1 / N ) * 0.5, ( 1 / M ) * 0.5 ] )		
+		framebuffer.width = Math.ceil( N / 4 )
+		
+		var glsl_shape = get_glsl_shape( tensor.shape )
+		var normalised_shape_halved = normalise_half( glsl_shape )
 		
 		data = {
-			UPshape:	{ type: 'uniform2fv', value: up_shape, comment: 'Unpacked # columns' },
-			UPhalfp:	{ type: 'uniform2fv', value: up_halfp, comment: 'Unpacked half pixel' }
+			UPshape: { type: 'uniform2fv', value: new Float32Array( glsl_shape ), comment: 'Unpacked shape' },
+			UPhalfp: { type: 'uniform2fv', value: new Float32Array( normalised_shape_halved ), comment: 'Unpacked half pixel' }
 		}
 
 		// Textures
 
 		// GLSL Settings
-		settings.packed = packed
-
-		// GLSL Functions
-		// TODO: automate function include (find available functions in supplied source)
-		functions.modulo 			= this.functions_src.modulo
-		functions.get_indices 		= this.functions_src.get_indices
-		functions.get_coords 		= this.functions_src.get_coords
-		functions.get_channel_value = this.functions_src.get_channel_value
+		settings.packed = asPacked
 
 		// GLSL Main
 		main = this.main_src.download_packed
@@ -649,11 +701,10 @@ TCompute.prototype.download = function( M, N, tensor, out, packed ) {
 		data: 			data,
 		textures: 		textures,
 		settings: 		settings,
-		functions: 		functions,
 		main: 			main
 	}
 
-	this.computePass.program = this.generateProgram( program_name, true )
+	this.computePass.program = this.generateProgram( program_name, false )
 
 	this.renderPass()
 }
@@ -726,25 +777,17 @@ TCompute.prototype.duplicate = function( M, N, tensor, out, packed ) {
 	var textures = {}
 	textures.A = { type: 'sampler2D', value: tensor, bindChannel: true, bindShape: false }
 
-	// GLSL Functions
-	var functions = {}
-	if ( !packed ) {
-		functions.get_channel_value = this.functions_src.get_channel_value
-		functions.set_channel_value = this.functions_src.set_channel_value
-	}
-
 	// GLSL Main
-	var flipy = tensor.isInput ? '' : '' // '#define FLIPY\r\n'
-	var main = packed ? flipy + this.main_src.duplicate_packed : flipy + this.main_src.duplicate
+	//var flipy = tensor.isInput ? '' : '' // '#define FLIPY\r\n'
+	var main = packed ? this.main_src.duplicate_packed : this.main_src.duplicate
 	
 	// Shader generation
-	var program_name = 'duplicate' + ( packed ? '_packed' : '' ) + ( tensor.isInput ? '_flipy' : '' )
+	var program_name = 'duplicate' + ( packed ? '_packed' : '' )
 	this.computePass = {
 		objects: 		objects,
 		framebuffer: 	framebuffer,
 		data: 			data,
 		textures: 		textures,
-		functions: 		functions,
 		main: 			main
 	}
 
@@ -1000,6 +1043,21 @@ TComputeState.prototype.viewport = function( viewport ) {
 TComputeState.prototype.resetGL = function() {}
 
 // Utils
+// User informs shape of matrix following M x N ( rows x columns ) notation as in math
+// inside glsl the convention adopted to refer to rows and columns is .y and .x respectively
+// as in x = abscissa and y = ordinate
+// this 
+function get_glsl_shape( shape ) {
+	return [ shape[ 1 ], shape[ 0 ] ]
+}
+// normalised shape, for use within shaders
+function normalise( glsl_shape ) {
+	return [ 1 / glsl_shape[ 0 ], 1 / glsl_shape[ 1 ] ]
+}
+// normalised shape pre-halved, to shorten in-glsl computations
+function normalise_half( glsl_shape ) {
+	return [ 0.5 / glsl_shape[ 0 ], 0.5 / glsl_shape[ 1 ] ]
+}
 // check viewports
 function viewportsEqual( cv, tv ) {
 	if ( cv[0] === tv.x && cv[1] === tv.y && cv[2] === tv.z && cv[3] === tv.w ) {

--- a/dist/Tensor.js
+++ b/dist/Tensor.js
@@ -31,10 +31,11 @@ function Tensor( shape, data/*, format, type*/ ) {
 		N = shape[1]
 
 	this.shape = shape
+	this.shape_asPacked = [ shape[0], Math.ceil( shape[1] / 4 ) ]
 
 	this.gl = gl
 	
-	this.requires_padding = N % 4 != 0
+	this.requires_padding = N % 4 !== 0
 	this.requires_encode = !this.gl.float_support
 
 	this.packed = false
@@ -47,26 +48,24 @@ function Tensor( shape, data/*, format, type*/ ) {
 		var glType = gl.context.FLOAT
 		/*if ( format !== undefined ) glFormat = gl.context[ format ]
 		if ( type !== undefined ) glType = gl.context[ type ]*/
-		this.texture = gl.setupTexture( M, N, null, false, glFormat, glType )
+		this.texture = gl.setupTexture( this.shape, null, glFormat, glType )
 		this.channel = 0
 	} else {
 		this.isInput = true
 		if ( !( data instanceof Float32Array ) ) data = Float32Array.from( data )
-		this.texture = gl.setupTexture( M, N, data, false, gl.context.LUMINANCE, gl.context.FLOAT )
+		this.texture = gl.setupTexture( this.shape, data, gl.context.LUMINANCE, gl.context.FLOAT )
 		this.channel = 0 // 0 = RED, 1 = GREEN, 2 = BLUE, 3 = ALPHA
 	}
 	// Create THREE texture
-	try {
-		if ( Number( THREE.REVISION ) >= 76 ) {
-			var texture = new THREE.GpuTexture( this.texture, this.shape[1], this.shape[0], THREE.RGBAFormat, THREE.FloatType )
-			this.THREE = texture
-		}
-	} catch ( error ) {}
+	if ( this.gl.withTHREE ) {
+		var texture = new THREE.GpuTexture( this.texture, this.shape[1], this.shape[0], THREE.RGBAFormat, THREE.FloatType )
+		this.THREE = texture
+	}
 
 }
 
-Tensor.setGL = function( gl_mngr ) {
-	gl = gl_mngr
+Tensor.setGL = function( gl_wrapper ) {
+	gl = gl_wrapper
 }
 
 Tensor.prototype.delete = function() {
@@ -112,9 +111,9 @@ Tensor.prototype.transfer = function( keep ) {
 		weblas.gpu.gl.context.deleteTexture(out)*/
 	} else {
 		// direct read floats, functions deal with adjusting ouput texture format/shape
-		out = gl.setupTexture( M, N, null, true, gl.context.RGBA, gl.context.FLOAT )
+		out = gl.setupTexture( this.shape_asPacked, null, gl.context.RGBA, gl.context.FLOAT )
 		gl.read( M, N, this, out )
-		result = gl.readFloat( M, N, true )
+		result = gl.readFramebuffer( this.shape_asPacked )
 		
 		// clean up
 		gl.context.deleteTexture(out)
@@ -142,6 +141,7 @@ Tensor.prototype.transpose = function( keep ) {
 	} else {
 		//tT = new weblas.unpacked.Tensor( [N, M], null )
 		tT = new Tensor( [N, M], null )
+		// TODO: set same channel as original? probably
 		gl.transpose( M, N, this, tT )
 	}
 
@@ -167,7 +167,7 @@ Tensor.prototype.pack = function() {
 		out
 	
 	// create output texture	
-	out = gl.setupTexture( M, N, null, true, gl.context.RGBA, gl.context.FLOAT )
+	out = gl.setupTexture( this.shape_asPacked, null, gl.context.RGBA, gl.context.FLOAT )
 	// invoke shader
 	gl.pack( M, N, this, out )
 	// clean up
@@ -197,7 +197,7 @@ Tensor.prototype.unpack = function( slot ) {
 	this.channel = typeof slot == 'undefined' ? 0 : slot
 
 	// create output texture
-	out = gl.setupTexture( M, N, null, false, gl.context.RGBA, gl.context.FLOAT )
+	out = gl.setupTexture( this.shape, null, gl.context.RGBA, gl.context.FLOAT )
 	// invoke shader
 	gl.unpack( M, N, this, out )
 	// clean up
@@ -212,42 +212,46 @@ Tensor.prototype.unpack = function( slot ) {
 	optionally allows to output as unpacked texture
 	defaults to packed type as that is what we usually need on the CPU side
  */
-Tensor.prototype.download = function( keep, unpacked, pretifyTensor ) {
-	var gl = this.gl
+Tensor.prototype.download = function() {
+	var options = arguments[ 0 ] instanceof Object ? arguments[ 0 ] : {}
+	options.asPacked = options.asPacked === undefined ? true : options.asPacked
+	options.pretify = options.pretify === undefined ? false : options.pretify
+	options.dispose = options.dispose === undefined ? false : options.dispose
 	
 	if ( this.packed ) {
 		console.info('download(): Packed texture - using transfer()')
-		return this.transfer( keep )
+		return this.transfer( !options.dispose )
 	}
-	/*if ( !gl.context.isTexture( this.texture ) )
-		throw new Error('download(): Texture is void.')*/
+	
+	var gl = this.gl
 
-	var M = this.shape[0],
-		N = this.shape[1],
-		out,
-		result,
-		result_str
+	var M = this.shape[0]
+	var	N = this.shape[1]
 	
-	var packed = unpacked === undefined ? true : !unpacked
+	// the actual required shape can be arbitrary, since the shader computes a flat sequence of elements
+	// the number of pixels (ie. M * N) is the actual minimum
+	// if we constrain N to a 4 multiple could we also simplify shader?
+	// readFramebuffer ignores buffer overruned elements
+	// lets keep the obvious logic here for now
+	var outputShape = options.asPacked ? this.shape_asPacked : this.shape
 	
-	// create output texture	
-	out = gl.setupTexture( M, N, null, packed, gl.context.RGBA, gl.context.FLOAT )
-	// invoke shader
-	gl.download( M, N, this, out, packed )
-	result = gl.readFloat( M, N, packed )
+	// prepare result texture
+	var output = gl.setupTexture( outputShape, null, gl.context.RGBA, gl.context.FLOAT )
+	
+	// invoke computation
+	gl.download( output, options.asPacked, this )
+	
+	// dump results to CPU, usually result stays in GPU and this step is skipped
+	var result = gl.readFramebuffer( outputShape )
 	
 	// clean up
-	gl.context.deleteTexture( out )
-	
-	if ( !keep ){
-		this.delete()
+	gl.context.deleteTexture( output )
+
+	if ( options.pretify && !this.packed ) { // never pretify packed tensors for now
+		result = pretify( { tensor: this, data: result, asPacked: options.asPacked } )
 	}
 	
-	var prety = pretifyTensor === undefined ? false : true
-	if ( prety ) {
-		result_str = pretify( { shape: this.shape, data: result, packed: packed } )
-		result = { data: result, string: result_str }
-	}
+	if ( options.dispose ) this.delete()
 	
 	return result
 }
@@ -302,13 +306,16 @@ Tensor.prototype.mixin = function ( red, green, blue, alpha ) {
 	//gl.context.deleteTexture( old_texture )
 }
 
-function pretify( tensor ) {
-	var shape = tensor.shape
-	var array = tensor.data
-	var packed = tensor.packed
+function pretify( options ) {
+	var shape = options.tensor === undefined ? options.shape : options.tensor.shape
+	var packed = options.tensor === undefined ? options.packed : options.tensor.packed
+	var channel = options.tensor === undefined ? options.channel : options.tensor.channel
+	
+	var data = options.data
+	var asPacked = options.asPacked
 	
 	var M = shape[ 0 ]
-	var N = packed ? shape[ 1 ] : shape[ 1 ] * 4
+	var N = asPacked ? shape[ 1 ] : shape[ 1 ] * 4
 	var stride = 1
 	var result_str = ''
 	
@@ -319,7 +326,7 @@ function pretify( tensor ) {
 	var col_maxD = new Float32Array( N )
 	for ( var j = 0; j < N; j++ ) {
 		for ( var i = 0; i < M; i++ ) {
-			var value = array[ i * N * stride + j * stride ]
+			var value = data[ i * N * stride + j * stride ]
 			col_max[ j ] = value > col_max[ j ] ? value : col_max[ j ]
 			if ( value % 1 !== 0 ) col_anyFr[ j ] = true
 		}
@@ -343,10 +350,10 @@ function pretify( tensor ) {
 			var first = j === 0
 			var last = j + 1 === N
 			
-			var pixel = fourths && !first && !last && !packed ? ' | ' : ''
-			var comma = ( ( !fourths || packed ) || first ) && !last ? ', ' : ''
+			var pixel = fourths && !first && !last && !asPacked ? ' | ' : ''
+			var comma = ( ( !fourths || asPacked ) || first ) && !last ? ', ' : ''
 			
-			var value = array[ i * N * stride + j * stride ]
+			var value = data[ i * N * stride + j * stride ]
 			var value_str = fillString( value, col_maxD[ j ], col_maxFD[ j ] )
 			
 			rj += value_str + comma + pixel
@@ -355,7 +362,8 @@ function pretify( tensor ) {
 		result_str += rj + endl
 	}
 	var packed_str = packed ? 'Packed' : 'Unpacked'
-	var info = 'Shape: ' + M + 'x' + N + ' | ' + packed_str + '\r\n'
+	var asPacked_str = asPacked ? 'asPacked' : 'asUnpacked'
+	var info = '\r\nShape: ' + M + 'x' + N + ' | ' + packed_str + ' | ' + asPacked_str + ' | Channel: ' + channel + '\r\n'
 	return info + result_str
 }
 module.exports.pretify = pretify
@@ -417,6 +425,8 @@ function mixin( red, green, blue, alpha ) {
 
 	//var mix = new weblas.unpacked.Tensor( tensors[0].shape, null )
 	var mix = new Tensor( tensors[0].shape, null )
+	// TODO: set channel as '4', to help distinguish from other tensor types?
+	// ie. '0' = default or 'n' = effective channel
 
 	var gl = tensors[0].gl // must fetch gl from first tensor, we're out of scope
 


### PR DESCRIPTION
- setupTexture() simplified, now directly accepts a shape
  makes use of precomputed asPacked shape
- readFloat() simplified and renamed to readFramebuffer() to accommodate
  future changes
- asPacked allows explicit distinction internal packed shape from
  equivalent shape only externally exposed as packed
- keep tensor by default, option renamed to dispose
- cleanup some deprecated code
